### PR TITLE
show gulp build error log 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,11 +75,17 @@ function watch(){
 
 function build(){
   var b = browserify(options);
-  return b.bundle()
+  b.bundle(function(err, buf){
+    if(err)process.exit(1);
+  })
   .on('log', gutil.log)
-  .on('error', gutil.log.bind(gutil, 'Browserify Error'))
+  .on('error',function(e){
+    gutil.log('Browserify Error',e.message);
+    gutil.log('Stack Trace:',e.stack);
+  })
   .pipe(source("bundle.js"))
   .pipe(buffer())
   .pipe(gulp.dest(DIST_CLIENT));
+
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,13 +75,14 @@ function watch(){
 
 function build(){
   var b = browserify(options);
-  b.bundle(function(err, buf){
-    if(err)process.exit(1);
-  })
+  b.bundle()
   .on('log', gutil.log)
   .on('error',function(e){
     gutil.log('Browserify Error',e.message);
     gutil.log('Stack Trace:',e.stack);
+    setTimeout(function(){
+      process.exit(1);
+    },1000);
   })
   .pipe(source("bundle.js"))
   .pipe(buffer())


### PR DESCRIPTION
Circle CIで```$ npm run build ```しないので, ビルド倒けても気付かない。
そこでCircle CIでnodeでビルドするようにした。
ビルドがこけると, ちゃんと赤く染まる。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fabnavi/fabnavi5/156)
<!-- Reviewable:end -->
